### PR TITLE
Run "exec server" when time wraps (to avoid losing the bots)

### DIFF
--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -1184,13 +1184,13 @@ void SV_Frame( int msec ) {
 	// 2giga-milliseconds = 23 days, so it won't be too often
 	if ( svs.time > 0x70000000 ) {
 		SV_Shutdown( "Restarting server due to time wrapping" );
-		Cbuf_AddText( va( "map %s\n", Cvar_VariableString( "mapname" ) ) );
+		Cbuf_AddText( "exec server\n" );
 		return;
 	}
 	// this can happen considerably earlier when lots of clients play and the map doesn't change
 	if ( svs.nextSnapshotEntities >= 0x7FFFFFFE - svs.numSnapshotEntities ) {
 		SV_Shutdown( "Restarting server due to numSnapshotEntities wrapping" );
-		Cbuf_AddText( va( "map %s\n", Cvar_VariableString( "mapname" ) ) );
+		Cbuf_AddText( "exec server\n" );
 		return;
 	}
 


### PR DESCRIPTION
Thanks to Daggo for the idea