### PR TITLE
Improved server restart (when the time wraps)

### DIFF
--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -276,6 +276,7 @@ extern	cvar_t	*sv_banFile;
 extern	cvar_t	*sv_maxOOBRate;
 extern	cvar_t	*sv_maxOOBRateIP;
 extern	cvar_t	*sv_autoWhitelist;
+extern  cvar_t  *sv_timeWrapCommand;
 
 extern	serverBan_t serverBans[SERVER_MAXBANS];
 extern	int serverBansCount;

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -1013,6 +1013,14 @@ void SV_Init (void) {
 	sv_maxOOBRate = Cvar_Get("sv_maxOOBRate", "1000", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands" );
 	sv_maxOOBRateIP = Cvar_Get("sv_maxOOBRateIP", "1", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands per IP address" );
 	sv_autoWhitelist = Cvar_Get("sv_autoWhitelist", "1", CVAR_ARCHIVE, "Save player IPs to allow them using server during DOS attack" );
+	sv_timeWrapCommand = Cvar_Get(
+		"sv_timeWrapCommand",
+		"",
+		CVAR_ARCHIVE,
+		"Which command should the server execute after it restarts due to time wrapping (or numSnapshotEntities wrapping)."
+        // Designed to add back the bots after the server restarts.
+		// Could be "exec addbots.cfg", or even "exec server.cfg" if need be.
+	);
 
 	// initialize bot cvars so they are listed and can be set before loading the botlib
 	SV_BotInitCvars();

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -1185,20 +1185,20 @@ void SV_Frame( int msec ) {
 	// 2giga-milliseconds = 23 days, so it won't be too often
 	if ( svs.time > 0x70000000 ) {
 		SV_Shutdown( "Restarting server due to time wrapping" );
-		Cbuf_AddText( "vstr nextmap\n" ); // Used to be "map %s\n", but it broke the rotation...
+		Cbuf_AddText( "vstr nextmap\n" ); // Used to be "map ...", but it broke the rotation...
 		// Optionally execute a custom command (typically, to add back the bots)
-		if (sv_timeWrapCommand->string[0]) {
-			Cbuf_AddText( sv_timeWrapCommand->string );
+		if ( sv_timeWrapCommand->string[0] ) {
+			Cbuf_AddText( "vstr sv_timeWrapCommand\n" );
 		}
 		return;
 	}
 	// this can happen considerably earlier when lots of clients play and the map doesn't change
 	if ( svs.nextSnapshotEntities >= 0x7FFFFFFE - svs.numSnapshotEntities ) {
 		SV_Shutdown( "Restarting server due to numSnapshotEntities wrapping" );
-		Cbuf_AddText( "vstr nextmap\n" ); // Used to be "map %s\n", but it broke the rotation...
+		Cbuf_AddText( "vstr nextmap\n" ); // Used to be "map ...", but it broke the rotation...
 		// Optionally execute a custom command (typically, to add back the bots)
-		if (sv_timeWrapCommand->string[0]) {
-			Cbuf_AddText( sv_timeWrapCommand->string );
+		if ( sv_timeWrapCommand->string[0] ) {
+			Cbuf_AddText( "vstr sv_timeWrapCommand\n" );
 		}
 		return;
 	}

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -72,6 +72,7 @@ cvar_t	*sv_banFile;
 cvar_t	*sv_maxOOBRate;
 cvar_t	*sv_maxOOBRateIP;
 cvar_t	*sv_autoWhitelist;
+cvar_t* sv_timeWrapCommand;
 
 serverBan_t serverBans[SERVER_MAXBANS];
 int serverBansCount = 0;
@@ -1184,13 +1185,21 @@ void SV_Frame( int msec ) {
 	// 2giga-milliseconds = 23 days, so it won't be too often
 	if ( svs.time > 0x70000000 ) {
 		SV_Shutdown( "Restarting server due to time wrapping" );
-		Cbuf_AddText( va( "map %s\n", Cvar_VariableString( "mapname" ) ) );
+		Cbuf_AddText( "vstr nextmap\n" ); // Used to be "map %s\n", but it broke the rotation...
+		// Optionally execute a custom command (typically, to add back the bots)
+		if (sv_timeWrapCommand->string[0]) {
+			Cbuf_AddText( sv_timeWrapCommand->string );
+		}
 		return;
 	}
 	// this can happen considerably earlier when lots of clients play and the map doesn't change
 	if ( svs.nextSnapshotEntities >= 0x7FFFFFFE - svs.numSnapshotEntities ) {
 		SV_Shutdown( "Restarting server due to numSnapshotEntities wrapping" );
-		Cbuf_AddText( va( "map %s\n", Cvar_VariableString( "mapname" ) ) );
+		Cbuf_AddText( "vstr nextmap\n" ); // Used to be "map %s\n", but it broke the rotation...
+		// Optionally execute a custom command (typically, to add back the bots)
+		if (sv_timeWrapCommand->string[0]) {
+			Cbuf_AddText( sv_timeWrapCommand->string );
+		}
 		return;
 	}
 


### PR DESCRIPTION
2 improvements:
- Used `vstr nextmap` instead of `map ...`.
  - `map ...` (as well as `map_restart`) seemed to break the rotation:  
    `nextmap` was then set to e.g. `map mp/ffa3` instead of e.g. `vstr d3`
- Added an `sv_timeWrapCommand` cvar (optional).
  - Specifies which command should be executed *after* the server restarts (and after `vstr nextmap`).
  - Designed to add back the bots after the server restarts.
  - Could be `exec addbots.cfg`, or even `exec server.cfg` if need be.

This is (in my opinion) a better alternative than PR #3 (and its hard-coded `exec server`).